### PR TITLE
Add inequality operator `!=`

### DIFF
--- a/doc/arbtt.xml
+++ b/doc/arbtt.xml
@@ -465,7 +465,8 @@ $ runhaskell Setup.hs install</screen>
 
           <production id="g-cmpop">
             <lhs>CmpOp</lhs>
-            <rhs><quote>&lt;=</quote> | <quote>&lt;</quote> | <quote>==</quote>
+            <rhs><quote>&lt;=</quote> | <quote>&lt;</quote> |
+            <quote>==</quote> | <quote>!=</quote>
             | <quote>&gt;</quote> | <quote>&gt;=</quote></rhs>
           </production>
 

--- a/src/Categorize.hs
+++ b/src/Categorize.hs
@@ -347,6 +347,7 @@ parseCmp = choice $ map (\(s,o) -> reservedOp lang s >> return o)
                          (">", Cmp (>)),
                          ("==",Cmp (==)),
                          ("=", Cmp (==)),
+                         ("!=",Cmp (/=)),
                          ("<", Cmp (<)),
                          ("<=",Cmp (<=))]
 


### PR DESCRIPTION
Just discovered arbtt and loving it!

I kind of missed the `!=` operator when writing rules, although you can always emulate it via `!` and `==` it feels nicer to be able to use `!=` instead.  

This pr add the `!=` operator for inequality, I was thinking about `/=` as in Haskell but I went with the mainstream `!=`.  If you prefer `/=` (I do!) We can change it