### PR TITLE
Add `$now` variable to get the current date

### DIFF
--- a/categorize.cfg
+++ b/categorize.cfg
@@ -125,4 +125,9 @@ format $date =~ ".*-03-19"  ==> tag period:on_a_special_day,
 month $date == 1 ==> tag month:January,
 month $date == 2 ==> tag month:February,
 year $date == 2010 ==> tag year:2010,
+
+-- “$now” evaluates to the current time
+day of month $now == day of month $date ==> tag current-day,
+month $now == month $date ==> tag current-month,
+year $now == year $date ==> tag current-year,
 -}

--- a/doc/arbtt.xml
+++ b/doc/arbtt.xml
@@ -432,7 +432,7 @@ $ runhaskell Setup.hs install</screen>
       <production id="g-date">
         <lhs>Date</lhs>
         <rhs> <quote>$date</quote> </rhs>
-        <!-- <rhs> <quote>$now</quote> </rhs> -->
+        <rhs> <quote>$now</quote> </rhs>
       </production>
 
       <production id="g-timediff">

--- a/src/Categorize.hs
+++ b/src/Categorize.hs
@@ -380,6 +380,8 @@ parseCondPrim = choice
                            return $ CondTime (getTimeVar "sampleage")
                       , do guard $ varname == "date"
                            return $ CondDate (getDateVar "date")
+                      , do guard $ varname == "now"
+                           return $ CondDate (getDateVar "now")
                       , do guard $ varname == "desktop"
                            return $ CondString (getVar "desktop")
                      ]
@@ -545,7 +547,8 @@ getTimeVar "time" ctx = Just $
 getTimeVar "sampleage" ctx = Just $ cCurrentTime ctx `diffUTCTime` tlTime (cNow ctx)
 
 getDateVar :: String -> CtxFun UTCTime
-getDateVar "date" ctx = Just $ tlTime (cNow ctx)
+getDateVar "date" = Just . tlTime . cNow
+getDateVar "now" = Just . cCurrentTime
 
 findActive :: [(Bool, t, t1)] -> Maybe (Bool, t, t1)
 findActive = find (\(a,_,_) -> a)                                 


### PR DESCRIPTION
Use case: I want to tag entries that are from *today*.

You can do this by checking `$date` with a hardcoded date that represents today, but that is cumbersome to change on a daily basis.

I saw that there already is the storage of the current time for `$sampleage`, so I added a new variable called `$now` that gives access to that.

When updating the documentation and grammar, there already was a commented out line with `$now`, was it removed somehow?

Anyway I added some examples in the categorize.cfg how I would use it.